### PR TITLE
adding ttuple to parameter specifications

### DIFF
--- a/udal/specification.py
+++ b/udal/specification.py
@@ -7,6 +7,7 @@ ParamType = Union[
     Literal['null', 'str', 'number', 'boolean'],
     Tuple[Literal['literal'], str | int | float],
     Tuple[Literal['list'], 'ParamType'],
+    Tuple[Literal['tuple'], 'ParamType'],
     Tuple[Literal['dict'], Literal['str'], 'ParamType'],
 ]
 """Description of the type of a parameter."""
@@ -18,6 +19,9 @@ def tliteral(l: str | int | float) -> ParamType:
 
 def tlist(pt: ParamType) -> ParamType:
     return ('list', pt)
+
+def ttuple(pt: ParamType) -> ParamType:
+    return ('tuple', pt)
 
 def tdict(pt: ParamType) -> ParamType:
     return ('dict', 'str', pt)


### PR DESCRIPTION
My ultimate goal is to check udal filters on two-tuple serving as a range filter with following valid options

(None, int) means `less than`
(int, None) means `greater than`
(int, int), within a range

Current commit only add `ttuple` to ParamType. Please consider where should I be checking the `int` and `None` values and enforce 2-tuple. I suppose that should be on the udal namedqueries themselves, correct?